### PR TITLE
[Feat] #4 로또번호 API를 통해 조회 데이터 연결하기

### DIFF
--- a/LotteryAPI.xcodeproj/project.pbxproj
+++ b/LotteryAPI.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4350DFDE2D3685E300670D84 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4350DFDD2D3685E300670D84 /* SnapKit */; };
+		4350DFE12D36871000670D84 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 4350DFE02D36871000670D84 /* Alamofire */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4350DFDE2D3685E300670D84 /* SnapKit in Frameworks */,
+				4350DFE12D36871000670D84 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +86,7 @@
 			name = LotteryAPI;
 			packageProductDependencies = (
 				4350DFDD2D3685E300670D84 /* SnapKit */,
+				4350DFE02D36871000670D84 /* Alamofire */,
 			);
 			productName = LotteryAPI;
 			productReference = 4350DF142D36398400670D84 /* LotteryAPI.app */;
@@ -115,6 +118,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				4350DFDC2D3685E300670D84 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				4350DFDF2D36871000670D84 /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4350DF152D36398400670D84 /* Products */;
@@ -354,6 +358,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		4350DFDF2D36871000670D84 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -361,6 +373,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4350DFDC2D3685E300670D84 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		4350DFE02D36871000670D84 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4350DFDF2D36871000670D84 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/LotteryAPI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LotteryAPI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "dd27728c8848101841bd8d45243ef43144e233aa3767c82656934b73447347b8",
+  "originHash" : "4d1117f641c000c6545947e4d48e126cc17473ec53f643df82900a33ad4936b2",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",

--- a/LotteryAPI/Model/Lottery.swift
+++ b/LotteryAPI/Model/Lottery.swift
@@ -1,0 +1,20 @@
+//
+//  Lottery.swift
+//  LotteryAPI
+//
+//  Created by Lee Wonsun on 1/14/25.
+//
+
+import Foundation
+
+struct Lottery: Decodable {
+    let drwNoDate: String
+    let drwNo: Int
+    let drwtNo1: Int
+    let drwtNo2: Int
+    let drwtNo3: Int
+    let drwtNo4: Int
+    let drwtNo5: Int
+    let drwtNo6: Int
+    let bnusNo: Int
+}

--- a/LotteryAPI/ViewController/LotteryViewController.swift
+++ b/LotteryAPI/ViewController/LotteryViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import Alamofire
 
 class LotteryViewController: UIViewController {
     
@@ -38,6 +39,7 @@ class LotteryViewController: UIViewController {
         
         view.backgroundColor = .white
         currentDraw = "1154회"
+        getAPIInfo("1154")
         
         configPicker()
         
@@ -58,7 +60,32 @@ class LotteryViewController: UIViewController {
             $0.layer.cornerRadius = $0.frame.width / 2
         }
     }
- 
+
+    func getAPIInfo(_ drwNo: String) {
+        let url = "https://www.dhlottery.co.kr/common.do?method=getLottoNumber&drwNo=\(drwNo)"
+        
+        AF.request(url, method: .get).responseDecodable(of: Lottery.self) { response in
+            
+            switch response.result {
+            case .success(let value):
+                self.drawNumber[0] = String(value.drwtNo1)
+                self.drawNumber[1] = String(value.drwtNo2)
+                self.drawNumber[2] = String(value.drwtNo3)
+                self.drawNumber[3] = String(value.drwtNo4)
+                self.drawNumber[4] = String(value.drwtNo5)
+                self.drawNumber[5] = String(value.drwtNo6)
+                self.drawNumber[7] = String(value.bnusNo)
+                
+                self.reloadDrawNumbers()
+                
+                self.lottoDateLabel.text = "\(value.drwNoDate) 추첨"
+                
+            case .failure(let value):
+                print(value
+                )
+            }
+        }
+    }
 }
 
 // MARK: - pickerView 설정
@@ -94,6 +121,8 @@ extension LotteryViewController: UIPickerViewDelegate, UIPickerViewDataSource {
         lottoDrawTextfield.text = title
         currentDraw = "\(title)회"
         resultLabel.attributedText = resultTitle()
+        
+        getAPIInfo(title)
     }
     
 }
@@ -192,6 +221,24 @@ extension LotteryViewController: LotteryResult {
     
         resultLabel.attributedText = resultTitle()
         
+        reloadDrawNumbers()
+        
+        bonusLabel.text = "보너스"
+        bonusLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        bonusLabel.textColor = .gray
+    }
+    
+    func resultTitle() -> NSAttributedString {
+        let title = currentDraw + " 당첨결과"
+        let attributedString = NSMutableAttributedString(string: title)
+        let stringLength = attributedString.length
+        attributedString.addAttributes([.foregroundColor: UIColor.lottoYellow, .font: UIFont.systemFont(ofSize: 30, weight: .semibold)],range: NSRange(location: 0, length: currentDraw.count))
+        attributedString.addAttributes([.foregroundColor: UIColor.label, .font: UIFont.systemFont(ofSize: 30, weight: .medium)], range: NSRange(location: currentDraw.count, length: stringLength - currentDraw.count))
+        
+        return attributedString
+    }
+    
+    func reloadDrawNumbers() {
         for index in 0...7 {
             drawingNumsLabels[index].text = drawNumber[index]
             drawingNumsLabels[index].textColor = .white
@@ -203,7 +250,6 @@ extension LotteryViewController: LotteryResult {
         drawingNumsLabels[6].textColor = .black
         drawingNumsLabels[6].textAlignment = .center
         drawingNumsLabels[6].font = .systemFont(ofSize: 20, weight: .semibold)
-        
         
         for index in 0...7 {
             drawingNumsViews[index].clipsToBounds = true
@@ -226,19 +272,5 @@ extension LotteryViewController: LotteryResult {
                 }
             }
         }
-        
-        bonusLabel.text = "보너스"
-        bonusLabel.font = .systemFont(ofSize: 13, weight: .medium)
-        bonusLabel.textColor = .gray
-    }
-    
-    func resultTitle() -> NSAttributedString {
-        let title = currentDraw + " 당첨결과"
-        let attributedString = NSMutableAttributedString(string: title)
-        let stringLength = attributedString.length
-        attributedString.addAttributes([.foregroundColor: UIColor.lottoYellow, .font: UIFont.systemFont(ofSize: 30, weight: .semibold)],range: NSRange(location: 0, length: currentDraw.count))
-        attributedString.addAttributes([.foregroundColor: UIColor.label, .font: UIFont.systemFont(ofSize: 30, weight: .medium)], range: NSRange(location: currentDraw.count, length: stringLength - currentDraw.count))
-        
-        return attributedString
     }
 }


### PR DESCRIPTION
## 한 일
1. 로또 API에서 정보 request 후 response받아 get 하여 필요한 데이터 필터링 진행
- Lottery 구조체로 날짜, 당첨번호, 회차 정보 받아옴
- 이 과정에서 뷰를 다시 덮어쓰는 실행이 필요해 config에 사용된 일부분 함수화하여 재사용함

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-14 at 21 28 49](https://github.com/user-attachments/assets/402503c3-8dcb-4426-a478-e076c89d3494)
